### PR TITLE
Potential fix for code scanning alert no. 1: Client-side URL redirect

### DIFF
--- a/public/redirect.html
+++ b/public/redirect.html
@@ -27,8 +27,16 @@
 <body><span>LOADING</span>
     <script>
         var hash = window.location.hash;
+        // Whitelist of allowed paths (can add more as needed)
+        var allowedRedirects = ["/dashboard", "/profile", "/home", "/"];
         if (hash.length) {
-            window.location = decodeURIComponent(hash.substr(1, hash.length));
+            var redirectTo = decodeURIComponent(hash.substr(1, hash.length));
+            // Only allow same-origin relative paths from the whitelist
+            if (allowedRedirects.includes(redirectTo)) {
+                window.location.pathname = redirectTo;
+            } else {
+                document.querySelector('span').innerHTML = 'Invalid or unauthorized redirect URL specified';
+            }
         } else {
             document.querySelector('span').innerHTML = 'No redirect URL specified';
         }


### PR DESCRIPTION
Potential fix for [https://github.com/PurrCoding/gm-mediaplayer/security/code-scanning/1](https://github.com/PurrCoding/gm-mediaplayer/security/code-scanning/1)

To address this vulnerability, we should only allow redirects to a set of known, safe URLs (or at minimum, restrict to same-origin URLs or paths). Since we can't assume server support, for a client-only fix, a simple, robust approach is to create a whitelist of allowed paths or URLs. Only redirect if the decoded hash matches one from this whitelist. The fix should keep the functionality of displaying a loading message and updating it to an error if the redirect target is invalid.

To implement the fix, edit public/redirect.html:
- Add a JavaScript whitelist (array) of permitted redirect targets.
- After decoding the hash, check if the intended redirect target is allowed – either by matching exactly, or (safely!) by verifying it's a relative path, or within same-origin.
- If allowed, perform the redirect. Otherwise, display an error message.
- No external dependencies needed; use plain JavaScript within the provided `<script>` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
